### PR TITLE
add exports to match react query exports

### DIFF
--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -1,6 +1,26 @@
-export * from './createQuery'
-export * from './QueryClientProvider'
-export * from './createMutation'
-export * from './useIsMutating'
-export * from './useIsFetching'
-export { QueryClient } from '@tanstack/query-core'
+// Re-export core
+export * from '@tanstack/query-core'
+
+// Solid Query
+export * from "./types"
+// export { useQueries } from './useQueries'
+// export type { QueriesResults, QueriesOptions } from './useQueries'
+export { createQuery } from './createQuery'
+export {
+  QueryClientContext as defaultContext,
+  QueryClientProvider,
+  useQueryClient,
+} from './QueryClientProvider'
+// export type { QueryClientProviderProps } from './QueryClientProvider'
+// export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
+// export { useHydrate, Hydrate } from './Hydrate'
+// export type { HydrateProps } from './Hydrate'
+// export {
+//   QueryErrorResetBoundary,
+//   useQueryErrorResetBoundary,
+// } from './QueryErrorResetBoundary'
+export { useIsFetching } from './useIsFetching'
+export { useIsMutating } from './useIsMutating'
+export { createMutation } from './createMutation'
+// export { useInfiniteQuery } from './useInfiniteQuery'
+// export { useIsRestoring, IsRestoringProvider } from './isRestoring'


### PR DESCRIPTION
Add exports to match react query exports. I've left the remaining exports commented out. We can uncomment as we implement them. Hopefully, that is a decent strategy for reaching react-query parity and doesn't clutter the code too much.

Needed these exports to implement the first example in the repo.