### PR TITLE
fix npm run build

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,6 @@ module.exports = {
       },
     ],
     '@babel/preset-typescript',
-    '@babel/react',
   ],
   plugins: [
     cjs && ['@babel/transform-modules-commonjs', { loose }],
@@ -32,4 +31,14 @@ module.exports = {
       },
     ],
   ].filter(Boolean),
+  overrides: [
+    {
+      exclude: './packages/solid-query/**',
+      presets: ['@babel/react'],
+    },
+    {
+      include: './packages/solid-query/**',
+      presets: ['babel-preset-solid'],
+    },
+  ],
 }

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tanstack/solid-query",
-  "version": "4.2.3",
+  "version": "4.3.0-beta.4",
   "description": "Hooks for managing, caching and syncing asynchronous and remote data in Solid",
   "author": "tannerlinsley",
   "license": "MIT",
@@ -10,20 +10,26 @@
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "module": "build/esm/index.js",
-  "main": "build/cjs/solid-query/src/index.js",
-  "browser": "build/umd/index.production.js",
-  "types": "build/types/packages/solid-query/src/index.d.ts",
-  "sideEffects": [],
+  "types": "build/lib/index.d.ts",
+  "main": "build/lib/index.js",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.mjs",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
+    "clean": "rm -rf ./build",
     "test:codemods": "../../node_modules/.bin/jest --config codemods/jest.config.js",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src",
     "test:jest": "yarn test:codemods && ../../node_modules/.bin/jest --config jest.config.js",
-    "test:jest:dev": "yarn test:jest --watch",
-    "compile": "../../node_modules/.bin/tsc -p tsconfig.json --noEmit --emitDeclarationOnly false"
+    "test:jest:dev": "yarn test:jest --watch"
   },
   "files": [
-    "build/*",
+    "build/lib/*",
+    "build/umd/*",
     "src",
     "codemods",
     "!codemods/jest.config.js",
@@ -35,7 +41,7 @@
     "jscodeshift": "^0.13.1"
   },
   "dependencies": {
-    "@tanstack/query-core": "4.2.3"
+    "@tanstack/query-core": "4.3.0-beta.4"
   },
   "peerDependencies": {
     "solid-js": "^1.5.4"

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -137,6 +137,20 @@ export default function rollup(options: RollupOptions): RollupOptions[] {
         '@tanstack/react-query': 'ReactQuery',
       },
     }),
+    ...buildConfigs({
+      name: 'solid-query',
+      packageDir: 'packages/solid-query',
+      jsName: 'SolidQuery',
+      outputFile: 'index',
+      entryFile: 'src/index.ts',
+      globals: {
+        'solid-js': 'Solid',
+        '@tanstack/query-core': 'QueryCore',
+      },
+      bundleUMDGlobals: [
+        '@tanstack/query-core',
+      ],
+    }),
   ]
 }
 


### PR DESCRIPTION
- Package.json wasn't set up correctly
- had to add solid-query to the rollup config
- had to conditionally apply babel react preset and babel solid preset

Previously `npm run build` only built the types. Not it builds the library.