### PR TITLE
get eslint to pass.

### DIFF
--- a/packages/solid-query/.eslintrc
+++ b/packages/solid-query/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "./tsconfig.json",
+    "project": "./tsconfig.lint.json",
     "sourceType": "module"
   },
   "rules": {

--- a/packages/solid-query/package.json
+++ b/packages/solid-query/package.json
@@ -22,9 +22,8 @@
   },
   "scripts": {
     "clean": "rm -rf ./build",
-    "test:codemods": "../../node_modules/.bin/jest --config codemods/jest.config.js",
     "test:eslint": "../../node_modules/.bin/eslint --ext .ts,.tsx ./src",
-    "test:jest": "yarn test:codemods && ../../node_modules/.bin/jest --config jest.config.js",
+    "test:jest": "../../node_modules/.bin/jest --config jest.config.js",
     "test:jest:dev": "yarn test:jest --watch"
   },
   "files": [

--- a/packages/solid-query/src/QueryClientProvider.tsx
+++ b/packages/solid-query/src/QueryClientProvider.tsx
@@ -26,8 +26,9 @@ interface Props {
 
 // Simple Query Client Context Provider
 export const QueryClientProvider: Component<Props> = (props) => {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime check.
   if (!props.client) {
-    throw new Error('No queryClient found.')
+    throw new Error('No QueryClient set, use QueryClientProvider to set one')
   }
 
   onMount(() => props.client.mount())

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -56,8 +56,8 @@ export function createBaseQuery<
   })
 
   createComputed(() => {
-    const defaultedOptions = queryClient.defaultQueryOptions(options)
-    observer.setOptions(defaultedOptions)
+    const newDefaultedOptions = queryClient.defaultQueryOptions(options)
+    observer.setOptions(newDefaultedOptions)
   })
 
   const handler = {

--- a/packages/solid-query/src/useIsFetching.ts
+++ b/packages/solid-query/src/useIsFetching.ts
@@ -42,9 +42,13 @@ export function useIsFetching(
   )
 
   createComputed(() => {
-    const [filtersObj, optionsObj = {}] = parseFilterArgs(arg1, arg2, arg3)
-    setFilters(filtersObj)
-    setOptions(optionsObj)
+    const [newFiltersObj, newOptionsObj = {}] = parseFilterArgs(
+      arg1,
+      arg2,
+      arg3,
+    )
+    setFilters(newFiltersObj)
+    setOptions(newOptionsObj)
   })
 
   const unsubscribe = queryCache().subscribe(() => {

--- a/packages/solid-query/src/utils.ts
+++ b/packages/solid-query/src/utils.ts
@@ -55,6 +55,6 @@ export function parseFilterArgs<
   return (
     isQueryKey(arg1)
       ? [{ ...arg2, queryKey: arg1() }, arg3]
-      : [{ ...arg1, queryKey: arg1?.queryKey?.() } || {}, arg2]
+      : [{ ...arg1, queryKey: arg1?.queryKey?.() }, arg2]
   ) as [ParseFilterArgs<TFilters>, TOptions]
 }

--- a/packages/solid-query/tsconfig.lint.json
+++ b/packages/solid-query/tsconfig.lint.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "./src",
+    "outDir": "./build/lib",
+    "tsBuildInfoFile": "./build/.tsbuildinfo",
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "../query-core" }
+  ]
+}


### PR DESCRIPTION
Fix a couple of eslint related issues.

The repo disables variable shadowing so the following is an error.

```ts
let foo = 1;

function bar() {
  // this variable shadows the outer variable.
  let foo = 2;
}
```

To get eslint working in vscode 

1. Install the [eslint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
2. Make eslint use correct working directories by adding the following in your settings.json

```jsonc
{
  // automatically resolve files relative to eslintrc
  "eslint.workingDirectories": [{ "mode": "auto" }],
}
```

From here on out `npm run test` should pass.