### PR TITLE
Add `createInfiniteQuery` Primitive

### DIFF
--- a/packages/solid-query/.eslintrc
+++ b/packages/solid-query/.eslintrc
@@ -1,6 +1,6 @@
 {
   "parserOptions": {
-    "project": "./tsconfig.lint.json",
+    "project": "./packages/solid-query/tsconfig.lint.json",
     "sourceType": "module"
   },
   "rules": {

--- a/packages/solid-query/src/createInfiniteQuery.ts
+++ b/packages/solid-query/src/createInfiniteQuery.ts
@@ -1,0 +1,115 @@
+import {
+  QueryObserver,
+  InfiniteQueryObserver,
+  QueryFunction,
+} from '@tanstack/query-core'
+import {
+  CreateInfiniteQueryOptions,
+  CreateInfiniteQueryResult,
+  SolidQueryKey,
+} from './types'
+import { createBaseQuery } from './createBaseQuery'
+import { createComputed } from 'solid-js'
+import { createStore } from 'solid-js/store'
+import { parseQueryArgs } from './utils'
+
+export function createInfiniteQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  options: CreateInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
+  >,
+): CreateInfiniteQueryResult<TData, TError>
+export function createInfiniteQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  options?: Omit<
+    CreateInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >,
+    'queryKey'
+  >,
+): CreateInfiniteQueryResult<TData, TError>
+export function createInfiniteQuery<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  queryKey: TQueryKey,
+  queryFn: QueryFunction<TQueryFnData, ReturnType<TQueryKey>>,
+  options?: Omit<
+    CreateInfiniteQueryOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryFnData,
+      TQueryKey
+    >,
+    'queryKey' | 'queryFn'
+  >,
+): CreateInfiniteQueryResult<TData, TError>
+export function createInfiniteQuery<
+  TQueryFnData,
+  TError,
+  TData = TQueryFnData,
+  TQueryKey extends SolidQueryKey = SolidQueryKey,
+>(
+  arg1:
+    | TQueryKey
+    | CreateInfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryFnData,
+        TQueryKey
+      >,
+  arg2?:
+    | QueryFunction<TQueryFnData, ReturnType<TQueryKey>>
+    | CreateInfiniteQueryOptions<
+        TQueryFnData,
+        TError,
+        TData,
+        TQueryFnData,
+        TQueryKey
+      >,
+  arg3?: CreateInfiniteQueryOptions<
+    TQueryFnData,
+    TError,
+    TData,
+    TQueryFnData,
+    TQueryKey
+  >,
+): CreateInfiniteQueryResult<TData, TError> {
+  // The parseQuery Args functions helps normalize the arguments into the correct form.
+  // Whatever the parameters are, they are normalized into the correct form.
+  const [parsedOptions, setParsedOptions] = createStore(
+    parseQueryArgs(arg1, arg2, arg3),
+  )
+
+  // Watch for changes in the options and update the parsed options.
+  createComputed(() => {
+    const newParsedOptions = parseQueryArgs(arg1, arg2, arg3)
+    setParsedOptions(newParsedOptions)
+  })
+
+  return createBaseQuery(
+    parsedOptions,
+    InfiniteQueryObserver as typeof QueryObserver,
+  ) as CreateInfiniteQueryResult<TData, TError>
+}

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -1,26 +1,7 @@
-// Re-export core
-export * from '@tanstack/query-core'
-
-// Solid Query
-export * from './types'
-// export { useQueries } from './useQueries'
-// export type { QueriesResults, QueriesOptions } from './useQueries'
-export { createQuery } from './createQuery'
-export {
-  QueryClientContext as defaultContext,
-  QueryClientProvider,
-  useQueryClient,
-} from './QueryClientProvider'
-// export type { QueryClientProviderProps } from './QueryClientProvider'
-// export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
-// export { useHydrate, Hydrate } from './Hydrate'
-// export type { HydrateProps } from './Hydrate'
-// export {
-//   QueryErrorResetBoundary,
-//   useQueryErrorResetBoundary,
-// } from './QueryErrorResetBoundary'
-export { useIsFetching } from './useIsFetching'
-export { useIsMutating } from './useIsMutating'
-export { createMutation } from './createMutation'
-// export { useInfiniteQuery } from './useInfiniteQuery'
-// export { useIsRestoring, IsRestoringProvider } from './isRestoring'
+export * from './createQuery'
+export * from './createInfiniteQuery'
+export * from './QueryClientProvider'
+export * from './createMutation'
+export * from './useIsMutating'
+export * from './useIsFetching'
+export { QueryClient } from '@tanstack/query-core'

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -1,4 +1,4 @@
-import type { Context, Accessor } from 'solid-js'
+import type { Context } from 'solid-js'
 import type {
   QueryClient,
   QueryKey,
@@ -8,7 +8,10 @@ import type {
   MutationObserverOptions,
   MutationObserverResult,
   DefinedQueryObserverResult,
+  InfiniteQueryObserverOptions,
+  InfiniteQueryObserverResult,
   QueryFilters,
+  QueryOptions,
 } from '@tanstack/query-core'
 
 export interface ContextOptions {
@@ -62,6 +65,34 @@ export type DefinedCreateQueryResult<
   TData = unknown,
   TError = unknown,
 > = DefinedCreateBaseQueryResult<TData, TError>
+
+export type ParseQueryArgs<
+  TOptions extends QueryOptions<any, any, any, ReturnType<TQueryKey>>,
+  TQueryKey extends () => readonly unknown[] = SolidQueryKey,
+> = TOptions['queryKey'] extends () => infer R
+  ? TOptions & { queryKey: R }
+  : TOptions
+
+/* --- Create Infinite Queries Types --- */
+export interface CreateInfiniteQueryOptions<
+  TQueryFnData = unknown,
+  TError = unknown,
+  TData = TQueryFnData,
+  TQueryData = TQueryFnData,
+  TQueryKey extends () => readonly unknown[] = SolidQueryKey,
+> extends ContextOptions,
+    InfiniteQueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      ReturnType<TQueryKey>
+    > {}
+
+export type CreateInfiniteQueryResult<
+  TData = unknown,
+  TError = unknown,
+> = InfiniteQueryObserverResult<TData, TError>
 
 /* --- Create Mutation Types --- */
 export interface CreateMutationOptions<

--- a/packages/solid-query/src/utils.ts
+++ b/packages/solid-query/src/utils.ts
@@ -1,10 +1,10 @@
 import {
-  CreateQueryOptions,
   SolidQueryKey,
   SolidQueryFilters,
   ParseFilterArgs,
+  ParseQueryArgs,
 } from './types'
-import { QueryFunction } from '@tanstack/query-core'
+import { QueryFunction, QueryOptions } from '@tanstack/query-core'
 
 export function isQueryKey(value: unknown): value is SolidQueryKey {
   return typeof value === 'function'
@@ -13,17 +13,13 @@ export function isQueryKey(value: unknown): value is SolidQueryKey {
 // The parseQuery Args functions helps normalize the arguments into the correct form.
 // Whatever the parameters are, they are normalized into the correct form.
 export function parseQueryArgs<
-  TQueryFnData,
-  TError,
-  TData = TQueryFnData,
+  TOptions extends QueryOptions<any, any, any, ReturnType<TQueryKey>>,
   TQueryKey extends () => readonly unknown[] = SolidQueryKey,
 >(
-  arg1: TQueryKey | CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  arg2?:
-    | QueryFunction<TQueryFnData, ReturnType<TQueryKey>>
-    | CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-  arg3?: CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-): CreateQueryOptions<TQueryFnData, TError, TData, TQueryKey> {
+  arg1: TQueryKey | TOptions,
+  arg2?: QueryFunction<any, ReturnType<TQueryKey>> | TOptions,
+  arg3?: TOptions,
+): ParseQueryArgs<TOptions, TQueryKey> {
   if (!isQueryKey(arg1)) {
     const { queryKey: solidKey, ...opts } = arg1 as any
     if (solidKey) {
@@ -32,7 +28,7 @@ export function parseQueryArgs<
         queryKey: solidKey(),
       }
     }
-    return arg1
+    return arg1 as any
   }
 
   if (typeof arg2 === 'function') {
@@ -53,6 +49,6 @@ export function parseFilterArgs<
   return (
     isQueryKey(arg1)
       ? [{ ...arg2, queryKey: arg1() }, arg3]
-      : [{ ...arg1, queryKey: arg1?.queryKey?.() } || {}, arg2]
+      : [{ ...arg1, queryKey: arg1?.queryKey?.() }, arg2]
   ) as [ParseFilterArgs<TFilters>, TOptions]
 }


### PR DESCRIPTION
This PR adds `createInfiniteQuery` primitive to `solid-query`. Notable things that were changes was the common parseQueryArgs function that now can be used to parse createQuery and createinfiniteQuery options. 