### PR TITLE
fix: create base query

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -7,7 +7,6 @@ import {
   onCleanup,
   createComputed,
   createResource,
-  batch,
 } from 'solid-js'
 import { createStore } from 'solid-js/store'
 
@@ -49,8 +48,7 @@ export function createBaseQuery<
   })
 
   const unsubscribe = observer.subscribe((result) => {
-    const reconciledResult = result
-    setState(reconciledResult)
+    setState(result)
     refetch()
   })
 
@@ -71,7 +69,10 @@ export function createBaseQuery<
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
       if (prop === 'data') {
-        return dataResource()
+        if (state.isLoading) {
+          return dataResource()
+        }
+        return state.data
       }
       return Reflect.get(target, prop)
     },

--- a/packages/solid-query/src/index.ts
+++ b/packages/solid-query/src/index.ts
@@ -1,7 +1,26 @@
-export * from './createQuery'
-export * from './createInfiniteQuery'
-export * from './QueryClientProvider'
-export * from './createMutation'
-export * from './useIsMutating'
-export * from './useIsFetching'
-export { QueryClient } from '@tanstack/query-core'
+// Re-export core
+export * from '@tanstack/query-core'
+
+// Solid Query
+export * from './types'
+// export { useQueries } from './useQueries'
+// export type { QueriesResults, QueriesOptions } from './useQueries'
+export { createQuery } from './createQuery'
+export {
+  QueryClientContext as defaultContext,
+  QueryClientProvider,
+  useQueryClient,
+} from './QueryClientProvider'
+// export type { QueryClientProviderProps } from './QueryClientProvider'
+// export type { QueryErrorResetBoundaryProps } from './QueryErrorResetBoundary'
+// export { useHydrate, Hydrate } from './Hydrate'
+// export type { HydrateProps } from './Hydrate'
+// export {
+//   QueryErrorResetBoundary,
+//   useQueryErrorResetBoundary,
+// } from './QueryErrorResetBoundary'
+export { useIsFetching } from './useIsFetching'
+export { useIsMutating } from './useIsMutating'
+export { createMutation } from './createMutation'
+export { createInfiniteQuery } from './createInfiniteQuery'
+// export { useIsRestoring, IsRestoringProvider } from './isRestoring'


### PR DESCRIPTION
Copies over the index file from `react-query` to match API and fix Jest tests and fixes the issue with create base query returning an invalid state while still triggering the `Suspense` loading state.