### PR TITLE
Fix: Create Base Query consistent return value

### DIFF
--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -7,7 +7,7 @@ import {
   onCleanup,
   createComputed,
   createResource,
-  batch,
+  on
 } from 'solid-js'
 import { createStore } from 'solid-js/store'
 
@@ -28,7 +28,7 @@ export function createBaseQuery<
   >,
   Observer: typeof QueryObserver,
 ): QueryObserverResult<TData, TError> {
-  const queryClient = useQueryClient()
+  const queryClient = useQueryClient({ context: options.context })
 
   const defaultedOptions = queryClient.defaultQueryOptions(options)
   defaultedOptions._optimisticResults = 'optimistic'
@@ -39,19 +39,22 @@ export function createBaseQuery<
     observer.getOptimisticResult(defaultedOptions),
   )
 
-  const [dataResource, { refetch }] = createResource<TData | undefined>(() => {
+  const [dataResource, { refetch }] = createResource<TData | undefined>((_, info) => {
     return new Promise((resolve) => {
-      if (state.isSuccess) resolve(state.data)
-      if (state.isError && !state.isFetching) {
-        throw state.error
+      // ?? What is happening here?? I have NO IDEA WHY INFO PUTS
+      // THE DATA IN the refetching property instead of the value property
+      const { refetching } = info as { refetching: false | QueryObserverResult<TData, TError>}
+      if (refetching) {
+        if (refetching.isSuccess) resolve(refetching.data)
+        if (refetching.isError && !refetching.isFetching) {
+          throw refetching.error
+        }
       }
     })
   })
 
-  const unsubscribe = observer.subscribe((result) => {
-    const reconciledResult = result
-    setState(reconciledResult)
-    refetch()
+  const unsubscribe = observer.subscribe((result) => {  
+    refetch(result)
   })
 
   onCleanup(() => unsubscribe())
@@ -64,6 +67,13 @@ export function createBaseQuery<
     const newDefaultedOptions = queryClient.defaultQueryOptions(options)
     observer.setOptions(newDefaultedOptions)
   })
+
+  createComputed(on(() => dataResource.state, () => {
+    const trackStates = ['pending', 'ready', 'errored'];
+    if(trackStates.includes(dataResource.state)) {
+      setState(observer.getCurrentResult())
+    }
+  }))
 
   const handler = {
     get(


### PR DESCRIPTION
This change switches how we handle queryObserver updates. This change will update the resource by first making a `refetch` call and then track the value updates using the resource states introduced in Solid v1.5^. These updates will then update the main state store in a computation which will enable us to make data consistent between the resource and the state store