### PR TITLE
Luke/suspense fixes

### DIFF
--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -807,6 +807,52 @@ describe("useQuery's in Suspense mode", () => {
     expect(queryFn).toHaveBeenCalledTimes(1)
   })
 
+  it('should not render suspense fallback when not enabled', async () => {
+    const key = queryKey()
+
+    function Page() {
+      const [enabled, setEnabled] = createSignal(false)
+      const result = createQuery(
+        key,
+        () => {
+          sleep(10)
+          return 'data'
+        },
+        {
+          suspense: true,
+          get enabled() {
+            return enabled()
+          },
+        },
+      )
+
+      return (
+        <div>
+          <button onClick={() => setEnabled(true)}>fire</button>
+          <h1>{result.data ?? 'default'}</h1>
+        </div>
+      )
+    }
+
+    render(() => (
+      <QueryClientProvider client={queryClient}>
+        <Suspense fallback="Loading...">
+          <Page />
+        </Suspense>
+      </QueryClientProvider>
+    ))
+
+    expect(screen.queryByText('Loading...')).toBeNull()
+    expect(screen.getByRole('heading').textContent).toBe('default')
+    await sleep(5)
+    fireEvent.click(screen.getByRole('button', { name: /fire/i }))
+    await waitFor(() => screen.getByText('Loading...'))
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading').textContent).toBe('data')
+    })
+  })
+
   it('should error catched in error boundary without infinite loop', async () => {
     const key = queryKey()
 

--- a/packages/solid-query/src/__tests__/suspense.test.tsx
+++ b/packages/solid-query/src/__tests__/suspense.test.tsx
@@ -8,6 +8,7 @@ import {
   CreateInfiniteQueryResult,
   createInfiniteQuery,
   QueryClientProvider,
+  CreateQueryResult,
 } from '..'
 import {
   createRenderEffect,

--- a/packages/solid-query/src/createBaseQuery.ts
+++ b/packages/solid-query/src/createBaseQuery.ts
@@ -98,7 +98,7 @@ export function createBaseQuery<
       target: QueryObserverResult<TData, TError>,
       prop: keyof QueryObserverResult<TData, TError>,
     ): any {
-      if (prop === 'data') {
+      if (prop === 'data' && target.isLoading && target.isFetching) {
         return dataResource()
       }
       return Reflect.get(target, prop)


### PR DESCRIPTION
Add missing import in suspense tests, add test and fix bug where queries with `enabled: false` triggered suspense. Same number of tests pass with the change. The new test fails without the change and passes with the change.